### PR TITLE
cursor test

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv='cache-control' content='no-cache'> 
+	<meta http-equiv='expires' content='0'> 
+	<meta http-equiv='pragma' content='no-cache'>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<script>
+		(function loadStyles() {
+			var segments = window.location.pathname.split('/').filter(Boolean);
+			var head = document.getElementsByTagName('head')[0];
+			function add(href) {
+				var link = document.createElement('link');
+				link.rel = 'stylesheet';
+				link.href = href;
+				link.onerror = function() {
+					// fallback to project page prefix if root fails
+					var alt = '/' + (segments[0] || '') + '/styles.css';
+					if (link.href !== window.location.origin + alt) {
+						link.href = alt;
+					}
+				};
+				head.appendChild(link);
+			}
+			add('/styles.css');
+		})();
+	</script>
+</head>
+<body>
+	<script>
+		(function() {
+			var segments = window.location.pathname.split('/').filter(Boolean);
+			var params = new URLSearchParams(window.location.search);
+			var notationDir = params.get('notation');
+			if (!notationDir) {
+				var last = segments[segments.length - 1] || '';
+				if (last === '' || /\.[a-zA-Z0-9]+$/.test(last)) {
+					notationDir = decodeURIComponent(segments[segments.length - 2] || 'worm');
+				} else {
+					notationDir = decodeURIComponent(last);
+				}
+			}
+			var encodedNotation = encodeURIComponent(notationDir);
+
+			function addScript(src, onerrorSrc, cb) {
+				var s = document.createElement('script');
+				s.async = false;
+				s.src = src;
+				s.onerror = function() {
+					if (onerrorSrc && s.src !== onerrorSrc) {
+						s.remove();
+						addScript(onerrorSrc, null, cb);
+					}
+				};
+				s.onload = function() { if (cb) cb(); };
+				document.body.appendChild(s);
+			}
+
+			// Load notation first, then main.js
+			addScript('/' + encodedNotation + '/notation.js', '/' + (segments[0] || '') + '/' + encodedNotation + '/notation.js', function() {
+				addScript('/main.js', '/' + (segments[0] || '') + '/main.js');
+			});
+		})();
+	</script>
+</body>
+</html>

--- a/GpSS/notation.js
+++ b/GpSS/notation.js
@@ -11,6 +11,16 @@ document.addEventListener("DOMContentLoaded", () => {
 	}
 });
 
+document.addEventListener("ancestorsChanged", () => {
+	const headerElement = document.body.querySelector("h2");
+	if (!headerElement) return;
+	if (maxAncestors == 1) {
+		headerElement.innerText = "Large Primitive Sequence System";
+	} else {
+		headerElement.innerText = ("Great ").repeat(maxAncestors - 2) + "Grandparent Sequence System";
+	}
+});
+
 class notation {
 	static title = "Grandparent Sequence System";
 	static footer = "<a href='viewer.html'>Row Viewer</a>";

--- a/main.js
+++ b/main.js
@@ -325,7 +325,15 @@ function initialize() {
 		if (notation.footer) {
 			footer.innerHTML = notation.footer + " | ";
 		}
-		footer.innerHTML += "<a href='..'>Index</a>";
+		const indexLink = document.createElement("a");
+		indexLink.textContent = "Index";
+		let indexHref = "..";
+		const baseEl = document.querySelector("base");
+		if (baseEl && baseEl.href) {
+			indexHref = baseEl.href;
+		}
+		indexLink.setAttribute("href", indexHref);
+		footer.appendChild(indexLink);
 		document.body.appendChild(footer);
 	}
 	


### PR DESCRIPTION
Adds a 404-based SPA fallback for GitHub Pages to remove duplicated `index.html` files in subfolders.

---
<a href="https://cursor.com/background-agent?bcId=bc-83953462-2637-4ee1-a043-f3040269ab4c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-83953462-2637-4ee1-a043-f3040269ab4c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

